### PR TITLE
feat: provide documentation for the UI server

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,8 @@
+# Config
+
+This directory contains all configuration for both the client and server of the Strimzi-ui ([described here](../docs/Architecture.md#configuration-and-feature-flagging)).
+
+- `runtime.js` - will contain all configuration options which require resolution at server runtime to return a value
+- `static.js` - will contain all configuration options where values can be defined literally
+- `featureflags.js` - will contain all feature flags. These could be defined literally, or require a callback to resolve (like `runtime.js` configuration values)
+- `index.js` - acts as a barrel file for all types, merging them together

--- a/package-lock.json
+++ b/package-lock.json
@@ -12915,12 +12915,6 @@
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
       "dev": true
     },
-    "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
-      "dev": true
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -16508,12 +16502,20 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
+      },
+      "dependencies": {
+        "node-forge": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+          "dev": true
+        }
       }
     },
     "semver": {

--- a/server/README.md
+++ b/server/README.md
@@ -1,3 +1,8 @@
 # Server
 
-Content to follow
+This directory contains all server code for the Strimzi UI - ie code which is responsible for the serving of and back channel logic to support the client code. A summary of contents can be found below:
+
+- [`core`](./core/README.md) - the core express server logic. This document also covers how the core module interacts with the other modules
+- [`client`](./client/README.md) - handlers for returning built client code to a user's web browser
+- [`mockapi`](./mockapi/README.md) - handlers for emulating a real instance of `Strimzi-admin` in dev and test scenarios
+- `main.js` - the build entry point for the production UI server. It checks for one argument, being the path to the configuration for the server which it then watches for modification, and owns the creation and management of a node `http`/`https` server (and binding express to it).

--- a/server/client/README.md
+++ b/server/client/README.md
@@ -1,0 +1,5 @@
+# client
+
+This module is responsible for serving the built client code, and does so on the `/` context root. All built client files are considered 'public', ie can be accessed without an authentication check, except a set defined subset representing the bundles which will only be retrieved once a user has authenticated and/or the backend server can support the page(s) those bundles represent. It also includes a behaviour if a request is not matched/served, it will redirect to `/index.html`.
+
+_Note_: Implementation to follow in a future PR

--- a/server/core/README.md
+++ b/server/core/README.md
@@ -1,0 +1,40 @@
+# core
+
+This module represents the core Express server. It also imports, configures and provides common items and capabilities to all modules, such as an authentication check middleware and logging utilities, as well as common middleware and security features.
+
+## Public api
+
+The core `app.js` file (in place of `router.js`) exports one function, `returnExpress`. This function takes one parameter, being a callback to get the current configuration. This is expected to be used in `main.js` to bind the returned express app to an http(s) server.
+
+## Interaction with other modules
+
+The core module will import and interact with all other modules to implement the server at run time. Thus, there are two
+
+### Import time
+
+The core module will import all modules' default export. This is expected to be a function, which takes two parameters:
+
+```
+const [mountPoint, routerToMount] = myModule(authMiddleware, router);
+```
+
+Where:
+
+- `authMiddleware` is an express middleware function to be inserted/used when a module's routes require a user to be authenticated to access them
+- `router` is an express [Router](https://expressjs.com/en/4x/api.html#router), which this module will append handlers to. This is provided so a common, pre module handler piece of express middleware can run [as described at runtime](#run-time) to provide context to the module
+
+This function is to return an array containing two items. The first is the context route this module will be mounted on (eg `/dev`). The second is the modified router, with handlers appended to it.
+
+This will then be mounted to the express server, ready to serve requests at runtime.
+
+### Run time
+
+At runtime, before any module handlers are called, a piece of express middleware defined by the core module will run. The result of this middleware is as follows:
+
+- Create a context object in `res.locals` called `strimziuicontext`. This context will contain:
+  - The current configuration for the server
+  - A unique request ID
+  - A pre configured set of loggers to use
+- Perform a check when receiving the request to see if the module is enabled, and thus should respond. If it is not enabled, a HTTP 404 RC will be returned, and the module's handlers will not be invoked
+
+_Note_: Implementation to follow in a future PR

--- a/server/main.js
+++ b/server/main.js
@@ -1,0 +1,5 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+// placeholder - this will be used as the entry point for the UI production server

--- a/server/mockapi/README.md
+++ b/server/mockapi/README.md
@@ -1,0 +1,5 @@
+# mockapi
+
+This module is used at development and test time to emulate a real instance of `Strimzi-admin`. It will return mock data as if a real instance of `Strimzi-admin` had responded, and also offer additional mutations to trigger responses needed in particular scenarios (eg user not authorised to perform an action etc).
+
+_Note_: Implementation to follow in a future PR


### PR DESCRIPTION
- adds build details for the server
- adds sections in Architecture.md to describe the server's structure,
as well as the Mock admin server section
- adds first pass of configuration documentation (relating to the
server)

Closes: #16
Contributes to: #13
Contributes to: #15

Signed-off-by: Matthew Chirgwin <chirmatt@uk.ibm.com>