### PR TITLE
chore: refactor server tests

### DIFF
--- a/server/api/api.steps.ts
+++ b/server/api/api.steps.ts
@@ -90,7 +90,6 @@ Then(
 
     const expectFailure = context.responseWillError ? true : false;
 
-    // check mock call counts
     await request.expect((res) => {
       // confirm the API module handles the response
       if (expectFailure) {

--- a/server/api/api.steps.ts
+++ b/server/api/api.steps.ts
@@ -91,38 +91,34 @@ Then(
     const expectFailure = context.responseWillError ? true : false;
 
     // check mock call counts
-    await request.then(
-      (res) => {
-        // check all mock calls for expected values
-        expect(createProxyServer).toHaveBeenCalledTimes(1);
-
-        // confirm the API module configured the proxy as expected first
-        const { target, ca, secure } = createProxyServer.mock.calls[0][0];
-        if (securedConfig) {
-          expect(target.startsWith('https://')).toBe(true);
-          expect(ca).toBe(configuration.proxy.transport.cert);
-          expect(secure).toBe(true);
-        } else {
-          expect(target.startsWith('http://')).toBe(true);
-          expect(ca).toBeUndefined();
-          expect(secure).toBe(false);
-        }
-        // confirm the expected context root is added to the end of the target
-        expect(target.endsWith(expectedContextRoot)).toBe(true);
-
-        expect(placeholderProxyEvent).not.toBeCalled(); // confirm placeholder event handlers are not called (ie ones provided by API module are)
-        // confirm the API module handles the response
-        if (expectFailure) {
-          expect(res.status).toBe(500);
-        } else {
-          expect(res.status).toBe(200);
-          expect(res.text).toEqual(successResponseBody);
-        }
-      },
-      (err) => {
-        throw err;
+    await request.expect((res) => {
+      // confirm the API module handles the response
+      if (expectFailure) {
+        expect(res.status).toBe(500);
+      } else {
+        expect(res.status).toBe(200);
+        expect(res.text).toEqual(successResponseBody);
       }
-    );
+    });
+
+    // check all mock calls for expected values
+    expect(createProxyServer).toHaveBeenCalledTimes(1);
+
+    // confirm the API module configured the proxy as expected first
+    const { target, ca, secure } = createProxyServer.mock.calls[0][0];
+    if (securedConfig) {
+      expect(target.startsWith('https://')).toBe(true);
+      expect(ca).toBe(configuration.proxy.transport.cert);
+      expect(secure).toBe(true);
+    } else {
+      expect(target.startsWith('http://')).toBe(true);
+      expect(ca).toBeUndefined();
+      expect(secure).toBe(false);
+    }
+    // confirm the expected context root is added to the end of the target
+    expect(target.endsWith(expectedContextRoot)).toBe(true);
+
+    expect(placeholderProxyEvent).not.toBeCalled(); // confirm placeholder event handlers are not called (ie ones provided by API module are)
   })
 );
 

--- a/server/config/config.steps.ts
+++ b/server/config/config.steps.ts
@@ -2,38 +2,30 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-import { Then, Fusion } from 'jest-cucumber-fusion';
-import { stepWithWorld } from 'test_common/commonServerSteps';
+import { Then, Fusion } from "jest-cucumber-fusion";
+import { stepWithWorld } from "test_common/commonServerSteps";
 
 Then(
-  'I get the expected config response',
-  stepWithWorld(async (world) => {
+  "I get the expected config response",
+  stepWithWorld((world) => {
     const { request } = world;
-    await request.then(
-      (res) => {
-        expect(res.status).toBe(200);
+    return request.expect(200).expect((res) => {
+      const { data } = res.body;
+      expect(data).not.toBeUndefined();
 
-        const { data } = res.body;
+      const { client, server, featureFlags } = data;
 
-        expect(data).not.toBeUndefined();
+      // confirm for all three config types the generated type names are present - shows the schema generation and resolvers are working
+      expect(client).not.toBeUndefined();
+      expect(client._generatedTypeName).toBe("client");
 
-        const { client, server, featureFlags } = data;
+      expect(server).not.toBeUndefined();
+      expect(server._generatedTypeName).toBe("server");
 
-        // confirm for all three config types the generated type names are present - shows the schema generation and resolvers are working
-        expect(client).not.toBeUndefined();
-        expect(client._generatedTypeName).toBe('client');
-
-        expect(server).not.toBeUndefined();
-        expect(server._generatedTypeName).toBe('server');
-
-        expect(featureFlags).not.toBeUndefined();
-        expect(featureFlags._generatedTypeName).toBe('featureFlags');
-      },
-      (err) => {
-        throw err;
-      }
-    );
+      expect(featureFlags).not.toBeUndefined();
+      expect(featureFlags._generatedTypeName).toBe("featureFlags");
+    });
   })
 );
 
-Fusion('config.feature');
+Fusion("config.feature");

--- a/server/log/log.steps.ts
+++ b/server/log/log.steps.ts
@@ -7,16 +7,9 @@ import { stepWithWorld } from 'test_common/commonServerSteps';
 
 Then(
   'I get the expected log response',
-  stepWithWorld(async (world) => {
+  stepWithWorld((world) => {
     const { request } = world;
-    await request.then(
-      (res) => {
-        expect(res.status).toBe(200);
-      },
-      (err) => {
-        throw err;
-      }
-    );
+    return request.expect(200);
   })
 );
 

--- a/server/mockapi/mockapi.steps.ts
+++ b/server/mockapi/mockapi.steps.ts
@@ -2,54 +2,40 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-import { Then, Fusion } from 'jest-cucumber-fusion';
-import { stepWithWorld } from 'test_common/commonServerSteps';
+import { Then, Fusion } from "jest-cucumber-fusion";
+import { stepWithWorld } from "test_common/commonServerSteps";
 
 Then(
-  'I get the expected mockapi response',
-  stepWithWorld(async (world) => {
+  "I get the expected mockapi response",
+  stepWithWorld((world) => {
     const { request } = world;
-    await request.then(
-      (res) => {
-        expect(res.status).toBe(200);
+    return request.expect(200).expect((res) => {
+      const { data } = res.body;
 
-        const { data } = res.body;
+      expect(data).not.toBeUndefined();
 
-        expect(data).not.toBeUndefined();
+      const { topics } = data;
 
-        const { topics } = data;
+      expect(topics).not.toBeUndefined();
 
-        expect(topics).not.toBeUndefined();
+      expect(Array.isArray(topics)).toBe(true);
+      expect(topics.length).not.toBeLessThan(1);
 
-        expect(Array.isArray(topics)).toBe(true);
-        expect(topics.length).not.toBeLessThan(1);
+      const { name, partitions, replicas } = topics[0];
 
-        const { name, partitions, replicas } = topics[0];
-
-        expect(name).not.toBeUndefined();
-        expect(partitions).not.toBeUndefined();
-        expect(replicas).not.toBeUndefined();
-      },
-      (err) => {
-        throw err;
-      }
-    );
+      expect(name).not.toBeUndefined();
+      expect(partitions).not.toBeUndefined();
+      expect(replicas).not.toBeUndefined();
+    });
   })
 );
 
 Then(
-  'I get the expected mockapi test endpoint response',
-  stepWithWorld(async (world) => {
+  "I get the expected mockapi test endpoint response",
+  stepWithWorld((world) => {
     const { request } = world;
-    await request.then(
-      (res) => {
-        expect(res.status).toBe(418);
-      },
-      (err) => {
-        throw err;
-      }
-    );
+    return request.expect(418);
   })
 );
 
-Fusion('mockapi.feature');
+Fusion("mockapi.feature");


### PR DESCRIPTION
- simplify tests by using supertest expectations
- remove unnecessary async functions

Contributes to: strimzi/strimzi-ui#117

Signed-off-by: Nic Townsend <nictownsend@uk.ibm.com>