### PR TITLE
fix: Sort express mountpoints to avoid requests getting hijacked

### DIFF
--- a/utils/dev_config/server.e2e.config.js
+++ b/utils/dev_config/server.e2e.config.js
@@ -16,6 +16,12 @@ module.exports = {
       ...serverCertificates,
     },
   },
+  logging: {
+    level: 'debug',
+    prettyPrint: {
+      translateTime: true,
+    },
+  },
   proxy: {
     ...mockadminServer,
     transport: {


### PR DESCRIPTION
 - This commit reverse-sorts the mountpoints added to express so that
shorter mountpoints such as '/' do not hijack traffic meant for other
mountpoints e.g. '/api' or '/log'. This is not seen when running the
dev server, as the dev server config does not enable the `client`
module.

Contributes to: #42

Signed-off-by: Andrew Borley <borley@uk.ibm.com>