### PR TITLE
fix: Allow logging functions to be destructured from logger object

### DIFF
--- a/server/client/controller.ts
+++ b/server/client/controller.ts
@@ -77,14 +77,14 @@ export const getFiles: (
 export const renderTemplate: (indexTemplate: string) => (req, res) => void = (
   indexTemplate
 ) => (req, res) => {
-  const { logger } = res.locals.strimziuicontext;
-  const { exit } = logger.entry('renderTemplate');
+  const { entry, debug } = res.locals.strimziuicontext.logger;
+  const { exit } = entry('renderTemplate');
   const { authentication } = res.locals.strimziuicontext
     .config as serverConfigType;
   const bootstrapConfigs = {
     authType: authentication.strategy,
   };
-  logger.debug('Templating bootstrap config containing %o', bootstrapConfigs);
+  debug('Templating bootstrap config containing %o', bootstrapConfigs);
   res.send(
     exit(
       render(indexTemplate, {

--- a/server/logging.ts
+++ b/server/logging.ts
@@ -56,16 +56,24 @@ const generateLogger: (
     requestID,
   });
 
-  const entryExitLogger = logger;
-  entryExitLogger.entry = (fnName, ...params) => {
-    logger.trace({ fnName, params }, 'entry');
-    return {
-      exit: (returns) => {
-        logger.trace({ fnName, returns }, 'exit');
-        return returns; // return params so you can do `return exit(.....)`
-      },
-    };
+  const entryExitLogger = {
+    ...logger,
+    entry: (fnName, ...params) => {
+      logger.trace({ fnName, params }, 'entry');
+      return {
+        exit: (returns) => {
+          logger.trace({ fnName, returns }, 'exit');
+          return returns; // return params so you can do `return exit(.....)`
+        },
+      };
+    },
   };
+
+  // Wrap the logging functions (trace(), debug(), info(), warn(), error(), and fatal()) in functions
+  // so that the entryExitLogger can be destructured. e.g: const {info} = res.locals.strimziuicontext.logger
+  Object.keys(logger.levels.values).forEach((level) => {
+    entryExitLogger[level] = (msg, ...args) => logger[level](msg, ...args);
+  });
 
   return entryExitLogger as entryExitLoggerType;
 };


### PR DESCRIPTION
 - This commit allows a destructuring assignment of the logging
functions in the logger object returned by `generateLogger()` e.g:
```
const {info} = res.locals.strimziuicontext.logger;
info('Some info-level logging message');
```

Contributes to: #42

Signed-off-by: Andrew Borley <borley@uk.ibm.com>