### PR TITLE
fix: load the api at a base path

### DIFF
--- a/build/webpack.client.dev.js
+++ b/build/webpack.client.dev.js
@@ -23,6 +23,7 @@ const {
   withMiniCssExtractPlugin,
   withWebpackBundleAnalyzerPlugin,
   withTsconfigPathsPlugin,
+  withApiBasePath,
 } = plugins;
 const {
   withStylingModuleLoader,
@@ -56,6 +57,7 @@ const devSpecificConfig = {
       analyzerMode: 'static',
       reportFilename: `${BUNDLE_ANALYSER_DIR}/bundles.html`, // when in dev mode, produce a static html file
     }),
+    withApiBasePath(process.env.BASE_PATH || ''),
   ],
   resolve: {
     plugins: [withTsconfigPathsPlugin({ configFile: 'client/tsconfig.json' })],

--- a/build/webpack.common.js
+++ b/build/webpack.common.js
@@ -64,6 +64,11 @@ const withNormalModuleReplacementPlugin = () =>
     resource.request = resource.request.replace('carbon', viewLayer);
   });
 
+const withApiBasePath = (basePath) =>
+  new webpack.DefinePlugin({
+    __API_BASE_PATH__: JSON.stringify(basePath),
+  });
+
 // common rules configuration
 const returnModuleRuleWithConfig = (defaultConfig = {}, defaultUse = []) => (
   customUse = [],
@@ -181,6 +186,7 @@ module.exports = {
     withMiniCssExtractPlugin,
     withWebpackBundleAnalyzerPlugin,
     withTsconfigPathsPlugin,
+    withApiBasePath,
   },
   moduleLoaders: {
     withStylingModuleLoader,

--- a/build/webpack.server.prod.js
+++ b/build/webpack.server.prod.js
@@ -15,7 +15,11 @@ const {
 } = require('./webpack.common.js');
 const { HEADER_TEXT } = require('../utils/tooling/constants.js');
 const { withTypeScriptModuleLoader } = moduleLoaders;
-const { withWebpackBundleAnalyzerPlugin, withTsconfigPathsPlugin } = plugins;
+const {
+  withWebpackBundleAnalyzerPlugin,
+  withTsconfigPathsPlugin,
+  withApiBasePath,
+} = plugins;
 
 const {
   PRODUCTION,
@@ -60,6 +64,7 @@ const prodSpecificConfig = {
     withWebpackBundleAnalyzerPlugin({
       reportFilename: `${BUNDLE_ANALYSER_DIR}/server-report.json`,
     }),
+    withApiBasePath(process.env.BASE_PATH || ''),
   ],
   resolve: {
     plugins: [withTsconfigPathsPlugin({ configFile: 'server/tsconfig.json' })],

--- a/client/Bootstrap/GraphQLClient/GraphQLClient.ts
+++ b/client/Bootstrap/GraphQLClient/GraphQLClient.ts
@@ -5,9 +5,11 @@
 
 import { ApolloClient, HttpLink, split, InMemoryCache } from '@apollo/client';
 
-const apiLink = new HttpLink({ uri: '/api', fetch });
+declare const __API_BASE_PATH__: string;
 
-const configLink = new HttpLink({ uri: '/config', fetch });
+const apiLink = new HttpLink({ uri: `${__API_BASE_PATH__}/api`, fetch });
+
+const configLink = new HttpLink({ uri: `${__API_BASE_PATH__}/config`, fetch });
 
 const splitLink = split(
   (operation) => operation.getContext().purpose === 'config',


### PR DESCRIPTION
Allows loading the API at a different base path

Signed-off-by: Pete Muir <pmuir@bleepbleep.org.uk>