### PR TITLE
fix: stop test assets bundled in production

### DIFF
--- a/client/Contexts/ConfigFeatureFlag/ConfigFeatureFlag.assets.ts
+++ b/client/Contexts/ConfigFeatureFlag/ConfigFeatureFlag.assets.ts
@@ -2,16 +2,10 @@
  * Copyright Strimzi authors.
  * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
  */
-// deliberately not using the barrel as causes a circular dependency
-import {
-  generateMockDataResponseForGQLRequest,
-  generateMockErrorResponseForGQLRequest,
-} from 'utils/test/withApollo/withApollo.util';
 import {
   ConfigFeatureFlagType,
   ApolloQueryResponseType,
 } from './ConfigFeatureFlag.types';
-import { GET_CONFIG } from 'Queries/Config';
 
 export const defaultClientConfig: ApolloQueryResponseType = {
   client: {},
@@ -32,60 +26,4 @@ export const defaultConfigFeatureFlagValue: ConfigFeatureFlagType = {
   triggerRefetch: /* istanbul ignore next */ () => {
     // NO-OP - placeholder
   },
-};
-
-const mockClientResponse = {
-  about: {
-    version: '1.2.3',
-  },
-};
-const mockFeatureFlagResponse = {
-  client: {
-    Home: {
-      showVersion: true,
-    },
-    Pages: {
-      PlaceholderHome: true,
-    },
-  },
-};
-
-const mockError = new Error('Example error case');
-
-export const mockData = {
-  mockClientResponse,
-  mockFeatureFlagResponse,
-  mockError,
-};
-
-const additionalRequestArgs = {
-  variables: {},
-  context: {
-    purpose: 'config',
-  },
-};
-
-const noOpRequest = generateMockDataResponseForGQLRequest(
-  GET_CONFIG,
-  {},
-  additionalRequestArgs
-);
-const successRequest = generateMockDataResponseForGQLRequest(
-  GET_CONFIG,
-  {
-    client: mockClientResponse,
-    featureFlags: mockFeatureFlagResponse,
-  },
-  additionalRequestArgs
-);
-const errorRequest = generateMockErrorResponseForGQLRequest(
-  GET_CONFIG,
-  mockError,
-  additionalRequestArgs
-);
-
-export const mockRequests = {
-  noOpRequest,
-  successRequest,
-  errorRequest,
 };

--- a/client/Contexts/ConfigFeatureFlag/ConfigFeatureFlag.spec.tsx
+++ b/client/Contexts/ConfigFeatureFlag/ConfigFeatureFlag.spec.tsx
@@ -21,11 +21,10 @@ import {
   ConfigFeatureFlagProvider,
   ConfigFeatureFlagConsumer,
 } from './Context';
+import { mockData, mockRequests } from './ConfigFeatureFlag.testassets';
 import {
   defaultClientConfig,
   defaultConfigFeatureFlagValue,
-  mockData,
-  mockRequests,
 } from './ConfigFeatureFlag.assets';
 
 import { ConfigFeatureFlagType } from './ConfigFeatureFlag.types';

--- a/client/Contexts/ConfigFeatureFlag/ConfigFeatureFlag.testassets.ts
+++ b/client/Contexts/ConfigFeatureFlag/ConfigFeatureFlag.testassets.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Strimzi authors.
+ * License: Apache License 2.0 (see the file LICENSE or http://apache.org/licenses/LICENSE-2.0.html).
+ */
+// deliberately not using the barrel as causes a circular dependency
+import {
+  generateMockDataResponseForGQLRequest,
+  generateMockErrorResponseForGQLRequest,
+} from 'utils/test/withApollo/withApollo.util';
+import { GET_CONFIG } from 'Queries/Config';
+
+const mockClientResponse = {
+  about: {
+    version: '1.2.3',
+  },
+};
+const mockFeatureFlagResponse = {
+  client: {
+    Home: {
+      showVersion: true,
+    },
+    Pages: {
+      PlaceholderHome: true,
+    },
+  },
+};
+
+const mockError = new Error('Example error case');
+
+export const mockData = {
+  mockClientResponse,
+  mockFeatureFlagResponse,
+  mockError,
+};
+
+const additionalRequestArgs = {
+  variables: {},
+  context: {
+    purpose: 'config',
+  },
+};
+
+const noOpRequest = generateMockDataResponseForGQLRequest(
+  GET_CONFIG,
+  {},
+  additionalRequestArgs
+);
+const successRequest = generateMockDataResponseForGQLRequest(
+  GET_CONFIG,
+  {
+    client: mockClientResponse,
+    featureFlags: mockFeatureFlagResponse,
+  },
+  additionalRequestArgs
+);
+const errorRequest = generateMockErrorResponseForGQLRequest(
+  GET_CONFIG,
+  mockError,
+  additionalRequestArgs
+);
+
+export const mockRequests = {
+  noOpRequest,
+  successRequest,
+  errorRequest,
+};


### PR DESCRIPTION
- restructure ConfigFeatureFlag assets so they are no longer
exporting test code as runtime dependencies

Contributes to: strimzi/strimzi-ui#152

Signed-off-by: Nic Townsend <nictownsend@uk.ibm.com>